### PR TITLE
Conditional imports to support operating with `pydantic>2` installed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/prefect_firebolt/credentials.py
+++ b/prefect_firebolt/credentials.py
@@ -6,7 +6,12 @@ from firebolt.async_db.connection import Connection, connect
 from firebolt.client.auth import Token, UsernamePassword
 from firebolt.client.constants import DEFAULT_API_URL
 from prefect.blocks.abstract import CredentialsBlock
-from pydantic import Field, SecretStr, root_validator
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, SecretStr, root_validator
+else:
+    from pydantic import Field, SecretStr, root_validator
 
 
 class FireboltCredentials(CredentialsBlock):

--- a/prefect_firebolt/database.py
+++ b/prefect_firebolt/database.py
@@ -5,7 +5,12 @@ from firebolt.async_db.connection import Connection
 from prefect import task
 from prefect.blocks.core import Block
 from prefect.utilities.asyncutils import sync_compatible
-from pydantic import Field, root_validator
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, root_validator
+else:
+    from pydantic import Field, root_validator
 
 from prefect_firebolt.credentials import FireboltCredentials
 


### PR DESCRIPTION
Following the compatibility work we've done in `prefect`, we also want to apply the
same compatibility changes to all Prefect-maintained collections.  We're following the
convention that Prefect will always use `pydantic<2` idioms, leaning on the
`pydantic.v1` module of `pydantic>2` to aid us in this.  With these changes, we can
operate normally regardless of the installed version.

Until `prefect` fully deprecates `pydantic` versions below 2.0, we'll continue to
maintain that constraint of using only v1 idioms.

This is part of a series of identical PRs for all of our maintained collections.